### PR TITLE
[ENH] - Add resources directory to bids.nf for optional input files

### DIFF
--- a/nextflow_config/fmriprep-20.2.0.nf.config
+++ b/nextflow_config/fmriprep-20.2.0.nf.config
@@ -1,5 +1,5 @@
 application = "fmriprep"
-version = "1.5.8"
+version = "20.2.0"
 simg = "/archive/code/containers/FMRIPREP/poldracklab_fmriprep_20.2.0-2020-09-28-24f22c9107bf.simg"
 invocation = "/archive/code/boutiques_jsons/invocations/fmriprep-20.2.0_invocation.json"
 descriptor = "/archive/code/boutiques_jsons/descriptors/fmriprep-20.2.0.json"


### PR DESCRIPTION
This feature was added to deal w/the fact that Boutiques does not automatically bind input filepaths to be available to singularity container executions.

TIGR_PURR now supports the --resources cmdline flag which will bind a resources directory so that pipelines requiring additional input files (i.e --bids-filter-file in fmriprep) are able to access these files.